### PR TITLE
Introduce golangci configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+linters:
+  # We do this to own which linters we want to enable.
+  # We are currently using all the default ones but this might change in the future.
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - asciicheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gosec
+    - exhaustive
+    - goimports
+    - gofumpt
+    - makezero
+    - nakedret
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - rowserrcheck
+    - sqlclosecheck
+    - tenv
+    - tparallel
+    - unparam
+    - usestdlibvars
+    - wastedassign
+
+
+linters-settings:
+  errorlint:
+    errorf: true
+  makezero:
+    always: true

--- a/cmd/app/providers.go
+++ b/cmd/app/providers.go
@@ -86,7 +86,7 @@ func provideQueries(ctx context.Context, dsn string) (*db.Queries, error) {
 	return db.New(conn), nil
 }
 
-func provideSlackService(ctx context.Context, q *db.Queries, c *cli.Context) genSlack.Service {
+func provideSlackService(_ context.Context, q *db.Queries, c *cli.Context) genSlack.Service {
 	return slack.New(
 		&slack.Config{
 			ClientSecret:  c.String("slack.client_secret"),

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -7,20 +7,19 @@ import (
 	"net"
 	"net/http"
 	"sync/atomic"
-
-	"github.com/rotabot-io/rotabot/slack"
-
-	"go.uber.org/zap/zapcore"
+	"time"
 
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zapio"
+
 	genSlack "github.com/rotabot-io/rotabot/gen/slack"
 	"github.com/rotabot-io/rotabot/lib/db"
-
 	"github.com/rotabot-io/rotabot/lib/middleware"
 	"github.com/rotabot-io/rotabot/lib/zapctx"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapio"
+	"github.com/rotabot-io/rotabot/slack"
 )
 
 type ServerParams struct {
@@ -84,7 +83,9 @@ func initHttpServer(p *ServerParams, rg *run.Group) *http.Server {
 		BaseContext: func(listener net.Listener) context.Context {
 			return ctx
 		},
-		ErrorLog: zapToStdLog(zapctx.Logger(ctx)),
+		ReadTimeout:       100 * time.Millisecond,
+		ReadHeaderTimeout: 100 * time.Millisecond,
+		ErrorLog:          zapToStdLog(zapctx.Logger(ctx)),
 	}
 
 	rg.Add(func() error {
@@ -123,7 +124,9 @@ func initMetricsServer(params *ServerParams, rg *run.Group) *http.Server {
 		BaseContext: func(listener net.Listener) context.Context {
 			return ctx
 		},
-		ErrorLog: zapToStdLog(zapctx.Logger(ctx)),
+		ReadTimeout:       100 * time.Millisecond,
+		ReadHeaderTimeout: 100 * time.Millisecond,
+		ErrorLog:          zapToStdLog(zapctx.Logger(ctx)),
 	}
 
 	rg.Add(func() error {

--- a/internal/postgresql.go
+++ b/internal/postgresql.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -35,7 +36,7 @@ func RunContainer(ctx context.Context) (*PostgresContainer, error) {
 		ExposedPorts: []string{"5432/tcp"},
 		Cmd:          []string{"postgres", "-c", "fsync=off"},
 		WaitingFor: wait.ForSQL("5432/tcp", "postgres", func(host string, port nat.Port) string {
-			connStr = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?%s", "rotabot", "password", host, port.Port(), "rotabot", "sslmode=disable")
+			connStr = fmt.Sprintf("postgres://%s:%s@%s/%s?%s", "rotabot", "password", net.JoinHostPort(host, port.Port()), "rotabot", "sslmode=disable")
 			return connStr
 		}).WithStartupTimeout(time.Second * 5),
 	}

--- a/lib/codecs/decoder_test.go
+++ b/lib/codecs/decoder_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Decoder", func() {
 	})
 
 	It("should decode valid json without errors", func() {
-		req := httptest.NewRequest("GET", "/hello", strings.NewReader(`{"foo": "bar"}`))
+		req := httptest.NewRequest(http.MethodGet, "/hello", strings.NewReader(`{"foo": "bar"}`))
 		req = req.WithContext(ctx)
 		rd := RequestDecoderWithLogs(req)
 
@@ -62,7 +62,7 @@ var _ = Describe("Decoder", func() {
 	})
 
 	It("should fail to decode invalid json", func() {
-		req := httptest.NewRequest("GET", "/hello", strings.NewReader(`{"foo"`))
+		req := httptest.NewRequest(http.MethodGet, "/hello", strings.NewReader(`{"foo"`))
 		req = req.WithContext(ctx)
 		rd := RequestDecoderWithLogs(req)
 

--- a/lib/codecs/encoder_test.go
+++ b/lib/codecs/encoder_test.go
@@ -3,6 +3,7 @@ package codecs
 import (
 	"context"
 	"fmt"
+	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
 
@@ -36,7 +37,7 @@ var _ = Describe("Encoder", func() {
 
 	Describe("RequestEncoderWithLogs", func() {
 		It("should encode valid json without errors", func() {
-			req := httptest.NewRequest("GET", "/hello", strings.NewReader(`{"foo": "bar"}`))
+			req := httptest.NewRequest(stdhttp.MethodGet, "/hello", strings.NewReader(`{"foo": "bar"}`))
 			req = req.WithContext(ctx)
 			rd := RequestDecoderWithLogs(req)
 
@@ -52,7 +53,7 @@ var _ = Describe("Encoder", func() {
 		})
 
 		It("should fail to encode with an invalid json", func() {
-			req := httptest.NewRequest("GET", "/hello", strings.NewReader(`{"foo"`))
+			req := httptest.NewRequest(stdhttp.MethodGet, "/hello", strings.NewReader(`{"foo"`))
 			req = req.WithContext(ctx)
 			rd := RequestDecoderWithLogs(req)
 

--- a/slack/verifier_test.go
+++ b/slack/verifier_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Verifier", func() {
 
 		handlerToTest := RequestVerifier(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}),
 			"SECRET",
 		)
@@ -38,7 +38,7 @@ var _ = Describe("Verifier", func() {
 
 		handlerToTest := RequestVerifier(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}),
 			"SECRET",
 		)
@@ -50,7 +50,7 @@ var _ = Describe("Verifier", func() {
 	})
 
 	It("Verifier reads headers and body", func() {
-		validSigningSecret := "e6b19c573432dcc6b075501d51b51bb8"
+		validSigningSecret := "e6b19c573432dcc6b075501d51b51bb8" // #nosec G101
 		validBody := `{"token":"aF5ynEYQH0dFN9imlgcADxDB","team_id":"XXXXXXXXX","api_app_id":"YYYYYYYYY","event":{"type":"app_mention","user":"AAAAAAAAA","text":"<@EEEEEEEEE> hello world","client_msg_id":"477cc591-ch73-a14z-4db8-g0cd76321bec","ts":"1531431954.000073","channel":"TTTTTTTTT","event_ts":"1531431954.000073"},"type":"event_callback","event_id":"TvBP7LRED7","event_time":1531431954,"authed_users":["EEEEEEEEE"]}`
 
 		req := httptest.NewRequest(http.MethodPost, "http://localhost:8080/slack/commands", strings.NewReader(validBody))
@@ -59,7 +59,7 @@ var _ = Describe("Verifier", func() {
 
 		handlerToTest := RequestVerifier(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}),
 			validSigningSecret,
 		)


### PR DESCRIPTION
Until now we were using the defaults, the most important bit of the config we are adding here is the fact that we are explicit about the linters we are running by disabling all the defaults and adding them ourselves