### PR TITLE
feat: Automatically update updated_at on change

### DIFF
--- a/assets/migrations/000002_init_db.up.sql
+++ b/assets/migrations/000002_init_db.up.sql
@@ -27,3 +27,14 @@ output;
 END;
 $$
 LANGUAGE plpgsql VOLATILE;
+
+-- https://x-team.com/blog/automatic-timestamps-with-postgresql/
+CREATE
+OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.UPDATED_AT = NOW();
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;

--- a/assets/migrations/000003_setup_tables.up.sql
+++ b/assets/migrations/000003_setup_tables.up.sql
@@ -10,3 +10,9 @@ CREATE TABLE ROTAS
 );
 
 CREATE UNIQUE INDEX idx_unique_rota_within_team_and_channel ON ROTAS (NAME, CHANNEL_ID, TEAM_ID);
+
+CREATE TRIGGER rotas_updated_at_trigger
+    BEFORE UPDATE
+    ON ROTAS
+    FOR EACH ROW
+    EXECUTE PROCEDURE trigger_set_timestamp();


### PR DESCRIPTION
We could do this ourselves on the code but I feel staying away of "DB Magic" at all cost is a bit of an extreme. This allows us to safely keep the updated_at up to date without needing to send it all the time (and miss it sometimes). Since I don't expect Rotabot to be a DB intense application where we update millions of resources at once I feel this is fine.