### PR TITLE
Make build run with oldstable again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+      - run: go version
       - name: Go Format
         run: gofmt -s -w . && git diff --exit-code
       - name: Go Tidy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ['oldstable', 'stable']
+        go: ['1.20', '1.21']
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ['stable']
+        go: ['oldstable', 'stable']
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      fail-fast: true
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/.github/workflows/sqlc.yml
+++ b/.github/workflows/sqlc.yml
@@ -22,8 +22,6 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     timeout-minutes: 5
-    strategy:
-      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -13,8 +13,6 @@ jobs:
     name: Vuln
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      fail-fast: true
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,11 @@ generate:
 
 .PHONY: test
 test:
-	go run github.com/onsi/ginkgo/v2/ginkgo  -r \
+	go run github.com/onsi/ginkgo/v2/ginkgo -r -p \
 		-randomize-all \
 		-randomize-suites \
 		-race \
 		-trace \
-		-procs=2 \
 		-poll-progress-after=10s \
 		-poll-progress-interval=10s \
 		--cover --coverprofile=cover.profile \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rotabot-io/rotabot
 
-go 1.19
+go 1.20
 
 require (
 	github.com/KimMachineGun/automemlimit v0.2.6


### PR DESCRIPTION
We had to remove oldstable because of goa.design Now that we have a new version of go we can bring it back