### PR TITLE
chore: Ensure only one job runs for a sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: ci
-permissions: { } # no need any permissions
+permissions: {} # no need any permissions
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: '0 10 * * 1' # run "At 10:00 on Monday"
   workflow_call:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check:
     name: Check
@@ -53,7 +56,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: ['1.20', '1.21']
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Sometimes people push changes shortly we should only care about the last version of these